### PR TITLE
Add Link to DockerSwarmStillRocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Swarm previously only supported local volumes, NFS, and a limited set of Docker 
 ### Articles and Sample Code
 
 - [Docker Swarm Rocks](https://dockerswarm.rocks/) - Collection of tutorials and code samples.
+- [Docker Swarm Still Rocks](https://dockerswarmstill.rocks/) - Continuation of above site with updated tutorials and code samples.
 - [Vault + Swarm](https://blog.sunekeller.dk/2019/04/vault-swarm-plugin-poc/) - Vault + Swarm Docker secrets plugin (proof of concept).
 - [dogvs.cat Sample Swarm Stacks](https://github.com/BretFisher/dogvscat) - Sample Docker Swarm cluster stack of tools including Traefik.
 - [Swarm vs. Compose for Production](https://github.com/BretFisher/ama/discussions/146) - Only one host for a production environment. What to use: docker-compose or single node swarm?


### PR DESCRIPTION
I have updated the original Docker Swarm Rocks website to [Docker Swarm Still Rocks](https://dockerswarmstill.rocks) and have made the site _self-hosting_, i.e. the site itself is hosted using Docker Swarm; all examples are used exactly the same way in production.

I have also contacted @tiangolo to link to this site, however I think _another_ link on this awesome list would not hurt. :)