### PR TITLE
Add MongoDB ReplicaSet Manager to Cluster Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This Awesome List is maintained by [@BretFisher](https://github.com/BretFisher) 
 - [AWS Docker Swarm Terraform Module](https://github.com/trajano/terraform-docker-swarm-aws)
 - [Swarmsible](https://github.com/neuroforgede/swarmsible) - Tooling to create and manage Docker Swarm clusters based on Ansible.
 - [Dockersamples Swarm Visualizer](https://github.com/dockersamples/docker-swarm-visualizer) - A basic web GUI visualizing a Swarm cluster. More of a concept and teaching UI than a production tool.
+- [MongoDB ReplicaSet Manager](https://github.com/BitWise-0x/MongoDB-ReplicaSet-Manager) - Automated deployment and management of MongoDB replica sets in Docker Swarm with intelligent failover and dynamic scaling.
 - [Mohsenasm Swarm Dashboard](https://github.com/mohsenasm/swarm-dashboard) - A Simple Monitoring Dashboard for Docker Swarm Cluster.
 - [Heckenmann Swarm Dashboard](https://github.com/heckenmann/docker-swarm-dashboard) - A Monitoring Dashboard for a Docker Swarm Cluster that gives you a bit more insights.
 - [swarmgate](https://github.com/neuroforgede/swarmgate) - Multitenancy for Docker Swarm - Docker Socket Proxy for use with Docker Swarm to have multiple tenants on a single Swarm.


### PR DESCRIPTION
## Summary
- Adds [MongoDB ReplicaSet Manager](https://github.com/BitWise-0x/MongoDB-ReplicaSet-Manager) to the **Cluster Management** section
- A Docker Swarm tool for automated MongoDB replica set deployment and management with intelligent failover and dynamic scaling

## Checklist
- [x] Follows the existing list format
- [x] Link is valid and project is working
- [x] Placed alphabetically in the appropriate category